### PR TITLE
Simplify Python code with flake8-simplify

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,9 +119,6 @@ ignore = [
   "S113",
   "S324",
   "S501",
-  "SIM103",
-  "SIM108",
-  "SIM118",
   ]
 line-length = 160
 target-version = "py37"
@@ -133,6 +130,8 @@ known-first-party = ["config"]
 max-complexity = 11
 
 [tool.ruff.per-file-ignores]
+"src/models/api/job/article_job.py" = ["SIM103"]
+"src/models/wikimedia/wikipedia/reference/generic.py" = ["SIM103"]
 "tests/*" = ["PT009", "PT018", "RUF001", "RUF003", "S101"]
 
 [build-system]

--- a/src/models/identifiers_checking/doi.py
+++ b/src/models/identifiers_checking/doi.py
@@ -124,7 +124,7 @@ class Doi(BaseModel):
         datavalue = claim.mainsnak.datavalue
         # print(datavalue)
         value = datavalue["value"]
-        if isinstance(value, dict) and "id" in value.keys():
+        if isinstance(value, dict) and "id" in value:
             qid_value = value["id"]
             app.logger.debug(f"found P31: '{qid_value}'")
             if qid_value == retracted_item:

--- a/src/models/wikimedia/wikipedia/analyzer.py
+++ b/src/models/wikimedia/wikipedia/analyzer.py
@@ -127,10 +127,11 @@ class WikipediaAnalyzer(WariBaseModel):
             for reference in self.article.extractor.references:
                 if not reference:
                     raise MissingInformationError("raw_reference was None")
-                if reference.footnote_subtype:
-                    subtype = reference.footnote_subtype.value
-                else:
-                    subtype = ""
+                subtype = (
+                    reference.footnote_subtype.value
+                    if reference.footnote_subtype
+                    else ""
+                )
                 # if not rr.get_wikicode_as_string:
                 #     raise MissingInformationError()
                 data = ReferenceStatistic(

--- a/src/models/wikimedia/wikipedia/article.py
+++ b/src/models/wikimedia/wikipedia/article.py
@@ -47,10 +47,7 @@ class WikipediaArticle(WariBaseModel):
 
     @property
     def is_redirect(self) -> bool:
-        if "#REDIRECT" in str(self.wikitext)[:10]:
-            return True
-        else:
-            return False
+        return "#REDIRECT" in str(self.wikitext)[:10]
 
     # @property
     # def underscored_title(self):

--- a/src/models/wikimedia/wikipedia/reference/generic.py
+++ b/src/models/wikimedia/wikipedia/reference/generic.py
@@ -75,10 +75,11 @@ class WikipediaReference(JobBaseModel):
     def footnote_subtype(self) -> Optional[FootnoteSubtype]:
         type_ = None
         if self.is_footnote_reference:
-            if self.is_empty_named_reference:
-                type_ = FootnoteSubtype.NAMED
-            else:
-                type_ = FootnoteSubtype.CONTENT
+            type_ = (
+                FootnoteSubtype.NAMED
+                if self.is_empty_named_reference
+                else FootnoteSubtype.CONTENT
+            )
         return type_
 
     @property

--- a/src/models/wikimedia/wikipedia/reference/template/template.py
+++ b/src/models/wikimedia/wikipedia/reference/template/template.py
@@ -32,7 +32,7 @@ class WikipediaTemplate(BaseModel):
     def __first_parameter__(self) -> str:
         """Private helper method"""
         if self.parameters:
-            if "first_parameter" in self.parameters.keys():
+            if "first_parameter" in self.parameters:
                 return str(self.parameters["first_parameter"])
             else:
                 return ""
@@ -45,7 +45,7 @@ class WikipediaTemplate(BaseModel):
         if self.name == "isbn":
             self.isbn = self.__first_parameter__
         else:
-            if "isbn" in self.parameters.keys():
+            if "isbn" in self.parameters:
                 self.isbn = str(self.parameters["isbn"])
 
     @property
@@ -164,10 +164,11 @@ class WikipediaTemplate(BaseModel):
             value = str(parameter.value)  # mwpfh needs upcast to str
             if strip:
                 key = parameter.name.strip()
-                if self.__explicit__(parameter):
-                    value = parameter.value.strip()
-                else:
-                    value = str(parameter.value)
+                value = (
+                    parameter.value.strip()
+                    if self.__explicit__(parameter)
+                    else str(parameter.value)
+                )
             else:
                 key = str(parameter.name)
             # Remove comments added by Dennis


### PR DESCRIPTION
% `ruff --select=SIM --statistics .`
```
3	SIM103	[*] Return the condition `"#REDIRECT" in str(self.wikitext)[:10]` directly
3	SIM108	[*] Use ternary operator `subtype = reference.footnote_subtype.value if reference.footnote_subtype else ""` instead of `if`-`else`-block
3	SIM118	[*] Use `"first_parameter" in self.parameters` instead of `"first_parameter" in self.parameters.keys()`
```
% `ruff --select=SIM --fix .`
```
src/models/api/job/article_job.py:107:9: SIM103 Return the condition `re.fullmatch(horizontal_line_regex, self.regex)` directly
src/models/wikimedia/wikipedia/reference/generic.py:206:9: SIM103 Return the condition `self.is_general_reference` directly
Found 9 errors (7 fixed, 2 remaining).
```
You can look at the two instances which ruff chose not to autofix.